### PR TITLE
fix: ajuste url bd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ COPY . .
 # Bind your app to port 8080
 EXPOSE 8080
 
-# CMD [ "node", "server.js" ]
-CMD [ "node", "server.js" ]
+# CMD ["npm", "start"]
+CMD ["npm", "start"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,18 +10,19 @@ services:
       - ./init-mongodb:/docker-entrypoint-initdb.d
       - ./init-mongodb/data:/tmp/data
     networks:
-      - node-network
-      
+      - node-network   
+  
   node-app:
-    build: .
-    image: node-app
-    container_name: node-app
-    ports:
-      - '8080:8080'
-    depends_on:
-      - mongodb
-    networks:
-      - node-network
+      build: .
+      image: node-app
+      container_name: node-app
+      ports:
+        - '8080:8080'
+      depends_on:
+        - mongodb
+      command: ["npm", "start"]
+      networks:
+        - node-network
 
 networks:
   node-network:

--- a/server.js
+++ b/server.js
@@ -8,8 +8,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const { MongoClient, ObjectId } = require('mongodb');
 const app = express();
-
-const url = 'mongodb://localhost:27017/';
+const url = 'mongodb://mongodb:27017/'; 
 const dbName = 'practica-database';
 const collectionName = 'users';
 const port = 8080;


### PR DESCRIPTION
### Ajuste Conexión mongodb

1. Se ajusta inicialización de node
```bash
npm start
```
2. se ajusta url de conexión a base  datos mongodb desde docker
```bash
const url = 'mongodb://mongodb:27017/'
```
Este PR realiza un ajuste en la configuración de la conexión a la base de datos MongoDB durante la dockerización del proyecto practica-docker

